### PR TITLE
Convert from roman to decimal

### DIFF
--- a/decimal_sequence.rb
+++ b/decimal_sequence.rb
@@ -8,4 +8,16 @@ class DecimalSequence
   def add(digit)
     @value << digit
   end
+
+  def aggregate()
+    result = @value.first
+    @value.each_cons(2) { |pair|
+      if pair[1] < pair[0]
+        result -= pair[1]
+      else
+        result += pair[1]
+      end
+    }
+    result
+  end
 end

--- a/roman_decimal_translator.rb
+++ b/roman_decimal_translator.rb
@@ -16,11 +16,11 @@ class RomanDecimalTranslator
   end
 
   def call(string)
-    string.downcase
+    string = string.downcase
     decimal_conversion = DecimalSequence.new()
-    string.each_char { |c|
+    string.reverse.each_char { |c|
       decimal_conversion.add(@definitions[c])
     }
-    decimal_conversion
+    decimal_conversion.aggregate()
   end
 end

--- a/spec/decimal_sequence_spec.rb
+++ b/spec/decimal_sequence_spec.rb
@@ -16,4 +16,16 @@ describe DecimalSequence do
     sequence = DecimalSequence.new()
     expect(sequence.value).to eq([])
   end
+
+  context "aggregates itself" do
+    it "sums non-decreasing terms" do
+      sequence = DecimalSequence.new([10, 10, 100])
+      expect(sequence.aggregate()).to eq(120)
+    end
+
+    it "subtracts decreasing terms" do
+      sequence = DecimalSequence.new([10, 1, 100])
+      expect(sequence.aggregate()).to eq(109)
+    end
+  end
 end

--- a/spec/roman_decimal_translator_spec.rb
+++ b/spec/roman_decimal_translator_spec.rb
@@ -4,51 +4,65 @@ describe RomanDecimalTranslator do
   translator = RomanDecimalTranslator.new()
   
   it "translates i to 1" do
-    test_string = "ii"
+    test_string = "I"
     translation = translator.call(test_string)
 
-    expect(translation.value).to eq([1, 1])
+    expect(translation).to eq(1)
   end
 
   it "translates v to 5" do
-    test_string = "vi"
+    test_string = "V"
     translation = translator.call(test_string)
 
-    expect(translation.value).to eq([5, 1])
+    expect(translation).to eq(5)
   end
 
   it "translates x to 10" do
-    test_string = "xxv"
+    test_string = "x"
     translation = translator.call(test_string)
 
-    expect(translation.value).to eq([10, 10, 5])
+    expect(translation).to eq(10)
   end
 
   it "translates l to 50" do
-    test_string = "lxxi"
+    test_string = "L"
     translation = translator.call(test_string)
 
-    expect(translation.value).to eq([50, 10, 10, 1])
+    expect(translation).to eq(50)
   end
 
   it "translates c to 100" do
-    test_string = "ccc"
+    test_string = "C"
     translation = translator.call(test_string)
 
-    expect(translation.value).to eq([100, 100, 100])
+    expect(translation).to eq(100)
   end
 
   it "translates d to 500" do
-    test_string = "dccxi"
+    test_string = "D"
     translation = translator.call(test_string)
 
-    expect(translation.value).to eq([500, 100, 100, 10, 1])
+    expect(translation).to eq(500)
   end
 
   it "translates m to 1000" do
-    test_string = "mmdccv"
+    test_string = "m"
     translation = translator.call(test_string)
 
-    expect(translation.value).to eq([1000, 1000, 500, 100, 100, 5])
+    expect(translation).to eq(1000)
+  end
+
+  it "translates multi-character numerals" do
+    test_string = "mdcclxxvii"
+    translation = translator.call(test_string)
+
+    expect(translation).to eq(1777)
+  end
+
+  it "translates multi-character numerals with subtraction terms" do
+    test_string = "MCDXCIV"
+    translation = translator.call(test_string)
+
+    expect(translation).to eq(1494)
   end
 end


### PR DESCRIPTION
Switching to using PRs because it might improve how we
look through this later, and because it helps me catch errors.

Previously, the roman numeral translator only translated a roman
numeral string into a decimal sequence. This improved version will
return the true translated decimal value. 

DecimalSequence handles aggregating itself, so it is still successfully
masking the list structure (yay!).
I'm not sure if the translator should really know that the digits should
be passed in least significant -> most significant order. It seems like
it would only know that's important if it knew aggregate()'s implementation
details. But I'm going with it for now!