### PR TITLE
Roman numeral validator

### DIFF
--- a/roman_validator.rb
+++ b/roman_validator.rb
@@ -1,0 +1,21 @@
+class RomanValidator
+  ILLEGAL_PREFIXES = {
+    "i" => [],
+    "v" => [],
+    "x" => ["v"],
+    "l" => ["v", "i"],
+    "c" => ["l"],
+    "d" => ["l", "x", "v", "i"],
+    "m" => ["d", "l", "x", "v", "i"]
+  }
+
+  def call(string)
+    !contains_illegal_prefixes?(string)
+  end
+
+  def contains_illegal_prefixes? (string)
+    string.each_char.each_cons(2).any? { |prefix, suffix|
+      ILLEGAL_PREFIXES[suffix].include?(prefix)
+    }
+  end
+end

--- a/spec/roman_validator_spec.rb
+++ b/spec/roman_validator_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../roman_validator'
+
+describe RomanValidator do
+  validator = RomanValidator.new()
+
+  it "rejects strings that have digits with illegal right neighbors" do
+    test_string = "vl"
+    result = validator.call(test_string)
+    expect(result).to be(false)
+  end
+
+  it "approves strings that have digits with legal right neighbors" do
+    test_string = "mlxi"
+    result = validator.call(test_string)
+    expect(result).to be(true)
+  end
+end


### PR DESCRIPTION
Before we translate and operate on our input terms, we need to validate
them. This needs to be expanded in the future, but for now there's
a basic check to see if each digit is followed by something legal.