### PR TITLE
Convert to roman string

### DIFF
--- a/decimal_roman_translator.rb
+++ b/decimal_roman_translator.rb
@@ -1,0 +1,42 @@
+class DecimalRomanTranslator
+  DECIMAL = {
+    1 => "i",
+    4 => "iv",
+    5 => "v",
+    9 => "ix",
+    10 => "x",
+    40 => "xl",
+    50 => "l",
+    90 => "xc",
+    100 => "c",
+    400 => "cd",
+    500 => "d",
+    900 => "cm",
+    1000 => "m"
+  }
+
+  def initialize()
+    @definitions = DECIMAL
+  end
+
+  def call(number)
+    convert(number.abs)
+  end
+
+  def convert(number)
+    result = ""
+    while(number > 0)
+      most_significant_digit = most_significant_digit(number)
+      next_numeral = @definitions[most_significant_digit]
+      number -= most_significant_digit
+      result << next_numeral
+    end
+    result
+  end
+
+  def most_significant_digit(number)
+    @definitions.keys.select{ |key|
+      key <= number  
+    }.max
+  end
+end

--- a/roman_calculator.rb
+++ b/roman_calculator.rb
@@ -1,10 +1,16 @@
 require_relative './roman_numeral'
+require_relative './decimal_roman_translator'
 
 class RomanCalculator
+  def initialize()
+    @to_decimal = DecimalRomanTranslator.new()
+  end
+
   #TODO: Use something besides eval here
   def call(input_opcode) 
     opcode = prepare(input_opcode)
-    eval(opcode)
+    result = eval(opcode)
+    @to_decimal.call(result)
   end
 
   def prepare(opcode)

--- a/spec/decimal_roman_translator_spec.rb
+++ b/spec/decimal_roman_translator_spec.rb
@@ -1,0 +1,26 @@
+require '../decimal_roman_translator'
+
+describe DecimalRomanTranslator do
+  translator = DecimalRomanTranslator.new()
+  
+  it "can translate a decimal string containing additive terms into a roman string" do
+    test_number = 1666
+    translation = translator.call(test_number)
+
+    expect(translation).to eq("mdclxvi")
+  end
+
+  it "can translate a decimal string containing subtractive terms into a roman string" do
+    test_number = 1999
+    translation = translator.call(test_number)
+
+    expect(translation).to eq("mcmxcix")
+  end
+
+  it "operates on absolute value if it receives a negative term" do
+    test_number = -20
+    translation = translator.call(test_number)
+
+    expect(translation).to eq("xx")
+  end
+end

--- a/spec/roman_calculator_spec.rb
+++ b/spec/roman_calculator_spec.rb
@@ -5,30 +5,30 @@ describe RomanCalculator do
   it "can handle terms in upper and lower case" do 
     opcode = "XXV + vii"
     result = calculator.call(opcode)
-    expect(result).to eq(32)
+    expect(result).to eq("xxxii")
   end
 
   it "can add terms" do 
     opcode = "XXV + xx"
     result = calculator.call(opcode)
-    expect(result).to eq(45)
+    expect(result).to eq("xlv")
   end
 
   it "can subtract terms" do 
     opcode = "c - x"
     result = calculator.call(opcode)
-    expect(result).to eq(90)
+    expect(result).to eq("xc")
   end
 
   it "can multiply terms" do 
     opcode = "xvi * ii"
     result = calculator.call(opcode)
-    expect(result).to eq(32)
+    expect(result).to eq("xxxii")
   end
 
   it "can divide terms" do 
     opcode = "mm / ii"
     result = calculator.call(opcode)
-    expect(result).to eq(1000)
+    expect(result).to eq("m")
   end
 end


### PR DESCRIPTION
Adding a decimal -> roman translator and using it in `RomanCalculator`
will let us return a roman string now instead of a number.